### PR TITLE
Simplify the basic workflow

### DIFF
--- a/.test/config.yaml
+++ b/.test/config.yaml
@@ -18,6 +18,8 @@ output_dir: output
 
 
 ########################################################################################################################
+kmer_histograms: True
+
 generate_assembly_stats: True  # True or False
 generate_prepropagation_stats: True  # True or False
 generate_postpropagation_stats: True  # True or False

--- a/config.yaml
+++ b/config.yaml
@@ -19,6 +19,8 @@ output_dir: output
 
 ########################################################################################################################
 # output configuration
+kmer_histograms: False
+
 generate_assembly_stats: True  # True or False
 generate_prepropagation_stats: False  # True or False
 generate_postpropagation_stats: False  # True or False

--- a/workflow/rules/asm.smk
+++ b/workflow/rules/asm.smk
@@ -28,46 +28,10 @@ rule asm_seq_formatting:
         fa=w_sample_source,
     output:
         fa=fn_asm_seq(_batch="{batch}", _sample="{sample}"),
-        fa_gz=fn_asm_seq_gz(_batch="{batch}", _sample="{sample}"),
-        fa_gz_size=fn_asm_seq_gz_size(_batch="{batch}", _sample="{sample}"),
-    params:
-        gzip_level=5,
     conda:
         "../envs/env.yaml"
     shell:
         """
         seqtk seq -U "{input.fa}" \\
-            | tee "{output.fa}" \\
-            | gzip -"{params.gzip_level}" \
-            > "{output.fa_gz}"
-
-        printf '%s\t%s\n' \\
-            {wildcards.sample} \\
-            $(wc -c < "{output.fa_gz}") \\
-            > "{output.fa_gz_size}"
-        """
-
-
-rule asm_gz_sizegram:
-    output:
-        tsv=fn_asm_seq_gz_sizegram(_batch="{batch}"),
-    input:
-        w_batch_asms_gz_sizes,
-    shell:
-        """
-        cat {input} > {output}
-        """
-
-
-rule asm_gz_sizegram_summary:
-    output:
-        tsv=fn_asm_seq_gz_sizegram_summary(_batch="{batch}"),
-    input:
-        tsv=fn_asm_seq_gz_sizegram(_batch="{batch}"),
-    shell:
-        """
-        printf '%s\t%s\n' \\
-            "asm_sum_gz_size" \\
-            $(cut -f2 {input} | paste -sd+ - | bc) \\
-            > {output.tsv} 
+            > "{output.fa}"
         """

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -126,22 +126,6 @@ def fn_asm_seq(_batch, _sample):
     return f"{dir_output()}/asm/{_batch}/{_sample}.fa"
 
 
-def fn_asm_seq_gz(_batch, _sample):
-    return f"{dir_output()}/asm/{_batch}/{_sample}.fa.gz"
-
-
-def fn_asm_seq_gz_size(_batch, _sample):
-    return f"{dir_output()}/asm/{_batch}/{_sample}.fa.gz.size"
-
-
-def fn_asm_seq_gz_sizegram(_batch):
-    return f"{dir_output()}/asm/{_batch}.asm.gz_sizegram"
-
-
-def fn_asm_seq_gz_sizegram_summary(_batch):
-    return f"{dir_output()}/asm/{_batch}.asm.gz_sizes.summary"
-
-
 def fn_asm_list(_batch):
     return f"{dir_output()}/asm/{_batch}.asm.list"
 
@@ -259,13 +243,6 @@ def w_sample_source(wildcards):
 def w_batch_asms(wildcards):
     batch = wildcards["batch"]
     l = [fn_asm_seq(batch, sample) for sample in BATCHES_FN[batch]]
-    return l
-
-
-# get all source files paths for a given batch
-def w_batch_asms_gz_sizes(wildcards):
-    batch = wildcards["batch"]
-    l = [fn_asm_seq_gz_size(batch, sample) for sample in BATCHES_FN[batch]]
     return l
 
 

--- a/workflow/rules/stats.smk
+++ b/workflow/rules/stats.smk
@@ -16,26 +16,34 @@ rule global_stats:
 def get_stats_files():
     stats_files = []
     if config["generate_assembly_stats"]:
+        if config["kmer_histograms"]:
+            stats_files.append(fn_asm_hist_summary(_batch="{batch}"))
+
         stats_files.extend(
             (
-                fn_asm_hist_summary(_batch="{batch}"),
                 fn_asm_nscl_summary(_batch="{batch}"),
                 fn_asm_compr_summary(_batch="{batch}"),
                 fn_asm_seq_gz_sizegram_summary(_batch="{batch}"),
             )
         )
     if config["generate_prepropagation_stats"]:
+        if config["kmer_histograms"]:
+            stats_files.append(
+                fn_pre_hist_summary(_batch="{batch}"),
+            )
         stats_files.extend(
             (
-                fn_pre_hist_summary(_batch="{batch}"),
                 fn_pre_nscl_summary(_batch="{batch}"),
                 fn_pre_compr_summary(_batch="{batch}"),
             )
         )
     if config["generate_postpropagation_stats"]:
+        if config["kmer_histograms"]:
+            stats_files.append(
+                fn_post_hist_summary(_batch="{batch}"),
+            )
         stats_files.extend(
             (
-                fn_post_hist_summary(_batch="{batch}"),
                 fn_post_nscl_summary(_batch="{batch}"),
                 fn_post_compr_summary(_batch="{batch}"),
             )

--- a/workflow/rules/stats.smk
+++ b/workflow/rules/stats.smk
@@ -23,7 +23,6 @@ def get_stats_files():
             (
                 fn_asm_nscl_summary(_batch="{batch}"),
                 fn_asm_compr_summary(_batch="{batch}"),
-                fn_asm_seq_gz_sizegram_summary(_batch="{batch}"),
             )
         )
     if config["generate_prepropagation_stats"]:


### PR DESCRIPTION
* Remove gzipping FASTA assemblies (used only for some baseline stats)
* Make k-mer counting optional