### PR TITLE
Split files between intermediate/ and output/

### DIFF
--- a/.test/config.yaml
+++ b/.test/config.yaml
@@ -21,7 +21,7 @@ output_dir: output
 ########################################################################################################################
 kmer_histograms: True
 
-generate_assembly_stats: True  # True or False
-generate_prepropagation_stats: True  # True or False
-generate_postpropagation_stats: True  # True or False
+compress_asm: True  # True or False
+compress_pre: True  # True or False
+compress_post: True  # True or False
 ########################################################################################################################

--- a/.test/config.yaml
+++ b/.test/config.yaml
@@ -13,6 +13,7 @@
 #          file. If this file is not provided, this pipeline builds a tree automatically using Mashtree.
 #   * These files must be at the top level of the given directory.
 input_dir: input
+intermediate_dir: intermediate
 output_dir: output
 ########################################################################################################################
 

--- a/.test/intermediate/.gitignore
+++ b/.test/intermediate/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,8 @@ conda: ## Create the conda environments
 
 
 rmstats: ## Remove stats
-	find results .test/results -name '*.global.tsv' | xargs rm -fv
-	find results .test/results -name '*.summary' | xargs rm -fv
+	find output .test/output -name 'stats*.tsv' | xargs rm -fv
+	find output .test/output -name '*.summary' | xargs rm -fv
 
 edit:
 	nvim -p workflow/Snakefile workflow/rules/*.smk

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ checkformat: ## Check source code format (developers)
 	yapf --diff --recursive workflow
 
 clean: ## Clean
-	rm -fvr output/*
+	rm -fvr intermediate/* output/*
 
 cleanall: clean ## Clean all
 

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ checkformat: ## Check source code format (developers)
 	yapf --diff --recursive workflow
 
 clean: ## Clean
-	rm -fvr intermediate/* output/*
+	rm -fvr {.,.test}/{intermediate,output}/*
 
 cleanall: clean ## Clean all
 

--- a/config.yaml
+++ b/config.yaml
@@ -13,6 +13,7 @@
 #          file. If this file is not provided, this pipeline builds a tree automatically using Mashtree.
 #   * These files must be at the top level of the given directory.
 input_dir: input
+intermediate_dir: intermediate
 output_dir: output
 ########################################################################################################################
 

--- a/config.yaml
+++ b/config.yaml
@@ -22,7 +22,7 @@ output_dir: output
 # output configuration
 kmer_histograms: False
 
-generate_assembly_stats: True  # True or False
-generate_prepropagation_stats: False  # True or False
-generate_postpropagation_stats: False  # True or False
+compress_asm: True  # True or False
+compress_pre: False  # True or False
+compress_post: False  # True or False
 ########################################################################################################################

--- a/intermediate/.gitignore
+++ b/intermediate/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -19,6 +19,7 @@ include: "rules/common.smk"
 rule all:
     input:
         fn_stats_batches(),
+        # TODO: add genome stats, make it configurable
         #fn_stats_genomes(),
 
 

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -18,7 +18,8 @@ include: "rules/common.smk"
 
 rule all:
     input:
-        fn_stats_global(),
+        fn_stats_batches(),
+        #fn_stats_genomes(),
 
 
 ##### Modules #####

--- a/workflow/rules/asm.smk
+++ b/workflow/rules/asm.smk
@@ -8,7 +8,7 @@ rule asm_list:
     Make a list of assemblies as they will appear in the .tar.xz archive
     """
     output:
-        list=fn_list(_batch="{batch}", protocol="asm"),
+        list=fn_list(_batch="{batch}", _protocol="asm"),
     input:
         list=fn_leaves_sorted(_batch="{batch}"),
         fa=w_batch_asms,

--- a/workflow/rules/asm.smk
+++ b/workflow/rules/asm.smk
@@ -24,10 +24,10 @@ rule asm_seq_formatting:
     """
     Turn an assembly file from the input into a well-behaved fasta file
     """
-    input:
-        fa=w_sample_source,
     output:
         fa=fn_asm_seq(_batch="{batch}", _sample="{sample}"),
+    input:
+        fa=w_sample_source,
     conda:
         "../envs/env.yaml"
     shell:

--- a/workflow/rules/asm.smk
+++ b/workflow/rules/asm.smk
@@ -8,7 +8,7 @@ rule asm_list:
     Make a list of assemblies as they will appear in the .tar.xz archive
     """
     output:
-        list=fn_asm_list(_batch="{batch}"),
+        list=fn_list(_batch="{batch}", protocol="asm"),
     input:
         list=fn_leaves_sorted(_batch="{batch}"),
         fa=w_batch_asms,

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -13,6 +13,10 @@ def dir_input():
     return Path(config["input_dir"])
 
 
+def dir_intermediate():
+    return Path(config["intermediate_dir"])
+
+
 def dir_output():
     return config["output_dir"]
 
@@ -70,11 +74,11 @@ def get_batches():
 
 
 def dir_prophyle(_batch):
-    return f"{dir_output()}/post/{_batch}"
+    return f"{dir_intermediate()}/post/{_batch}"
 
 
 def dir_prophyle_propagation(_batch):
-    return f"{dir_output()}/post/{_batch}/propagation"
+    return f"{dir_intermediate()}/post/{_batch}/propagation"
 
 
 ## FILE PATHS
@@ -85,11 +89,11 @@ def fn_stats_global():
 
 
 def fn_stats_batch_global(_batch):
-    return f"{dir_output()}/stats/{_batch}.global.tsv"
+    return f"{dir_intermediate()}/stats/{_batch}.global.tsv"
 
 
 def fn_stats_samples(_batch):
-    return f"{dir_output()}/stats/{_batch}.samples.tsv"
+    return f"{dir_intermediate()}/stats/{_batch}.samples.tsv"
 
 
 # *_list - list of files for compression in that order
@@ -100,38 +104,38 @@ def fn_stats_samples(_batch):
 
 
 def fn_tree_sorted(_batch):
-    return f"{dir_output()}/tree/{_batch}.nw"
+    return f"{dir_intermediate()}/tree/{_batch}.nw"
 
 
 def fn_tree_dirty(_batch):
-    return f"{dir_output()}/tree/{_batch}.nw_dirty"
+    return f"{dir_intermediate()}/tree/{_batch}.nw_dirty"
 
 
 def fn_leaves_sorted(_batch):
-    return f"{dir_output()}/tree/{_batch}.leaves"
+    return f"{dir_intermediate()}/tree/{_batch}.leaves"
 
 
 def fn_nodes_sorted(_batch):
-    return f"{dir_output()}/tree/{_batch}.nodes"
+    return f"{dir_intermediate()}/tree/{_batch}.nodes"
 
 
-#
+# Assemblies
 
 
 def fn_asm_seq_dir(_batch):
-    return f"{dir_output()}/asm/{_batch}"
+    return f"{dir_intermediate()}/asm/{_batch}"
 
 
 def fn_asm_seq(_batch, _sample):
-    return f"{dir_output()}/asm/{_batch}/{_sample}.fa"
+    return f"{dir_intermediate()}/asm/{_batch}/{_sample}.fa"
 
 
 def fn_asm_list(_batch):
-    return f"{dir_output()}/asm/{_batch}.asm.list"
+    return f"{dir_intermediate()}/asm/{_batch}.asm.list"
 
 
 def fn_asm_hist(_batch):
-    return f"{dir_output()}/asm/{_batch}.asm.hist"
+    return f"{dir_intermediate()}/asm/{_batch}.asm.hist"
 
 
 def fn_asm_hist_summary(_batch):
@@ -139,7 +143,7 @@ def fn_asm_hist_summary(_batch):
 
 
 def fn_asm_nscl(_batch):
-    return f"{dir_output()}/asm/{_batch}.asm.nscl"
+    return f"{dir_intermediate()}/asm/{_batch}.asm.nscl"
 
 
 def fn_asm_nscl_summary(_batch):
@@ -154,19 +158,19 @@ def fn_asm_compr_summary(_batch):
     return fn_asm_compr(_batch) + ".summary"
 
 
-#
+# Pre-propagation simplitigs
 
 
 def fn_pre_seq(_batch, _sample):
-    return f"{dir_output()}/pre/{_batch}/{_sample}.simpl"
+    return f"{dir_intermediate()}/pre/{_batch}/{_sample}.simpl"
 
 
 def fn_pre_list(_batch):
-    return f"{dir_output()}/pre/{_batch}.pre.list"
+    return f"{dir_intermediate()}/pre/{_batch}.pre.list"
 
 
 def fn_pre_hist(_batch):
-    return f"{dir_output()}/pre/{_batch}.pre.hist"
+    return f"{dir_intermediate()}/pre/{_batch}.pre.hist"
 
 
 def fn_pre_hist_summary(_batch):
@@ -174,7 +178,7 @@ def fn_pre_hist_summary(_batch):
 
 
 def fn_pre_nscl(_batch):
-    return f"{dir_output()}/pre/{_batch}.pre.nscl"
+    return f"{dir_intermediate()}/pre/{_batch}.pre.nscl"
 
 
 def fn_pre_nscl_summary(_batch):
@@ -189,23 +193,23 @@ def fn_pre_compr_summary(_batch):
     return fn_pre_compr(_batch) + ".summary"
 
 
-#
+# Post-propagation simplitigs
 
 
 def fn_post_seq0(_batch, _node):
-    return f"{dir_output()}/post/{_batch}/propagation/{_node}.reduced.fa"
+    return f"{dir_intermediate()}/post/{_batch}/propagation/{_node}.reduced.fa"
 
 
 def fn_post_seq(_batch, _node):
-    return f"{dir_output()}/post/{_batch}/{_node}.simpl"
+    return f"{dir_intermediate()}/post/{_batch}/{_node}.simpl"
 
 
 def fn_post_list(_batch):
-    return f"{dir_output()}/post/{_batch}.post.list"
+    return f"{dir_intermediate()}/post/{_batch}.post.list"
 
 
 def fn_post_hist(_batch):
-    return f"{dir_output()}/post/{_batch}.post.hist"
+    return f"{dir_intermediate()}/post/{_batch}.post.hist"
 
 
 def fn_post_hist_summary(_batch):
@@ -213,7 +217,7 @@ def fn_post_hist_summary(_batch):
 
 
 def fn_post_nscl(_batch):
-    return f"{dir_output()}/post/{_batch}.post.nscl"
+    return f"{dir_intermediate()}/post/{_batch}.post.nscl"
 
 
 def fn_post_nscl_summary(_batch):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -90,7 +90,7 @@ def dir_prophyle_propagation(_batch):
 
 
 def fn_stats_batches():
-    return f"{dir_output()}/global_stats.tsv"
+    return f"{dir_output()}/stats_batches.tsv"
 
 
 def fn_stats_batches_1batch(_batch):
@@ -146,7 +146,7 @@ def fn_nscl(_batch, _protocol):
 
 
 def fn_nscl_summary(_batch, _protocol):
-    return f"{dir_intermediate()}/{_protocol}/{_batch}.{_protocol}.summary"
+    return f"{dir_intermediate()}/{_protocol}/{_batch}.{_protocol}.nscl.summary"
 
 
 def fn_hist(_batch, _protocol):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -60,7 +60,7 @@ for x in res:
 wildcard_constraints:
     sample=r"[a-zA-Z0-9_-]+",
     batch=r"[a-zA-Z0-9_-]+",
-    stage=r"(asm|pre|post)",
+    protocol=r"(asm|pre|post)",
 
 
 ## BATCHES
@@ -84,6 +84,11 @@ def dir_prophyle_propagation(_batch):
 ## FILE PATHS
 
 
+#####################################
+# Global files for individual batches
+#####################################
+
+
 def fn_stats_global():
     return f"{dir_output()}/global_stats.tsv"
 
@@ -94,13 +99,6 @@ def fn_stats_batch_global(_batch):
 
 def fn_stats_samples(_batch):
     return f"{dir_intermediate()}/stats/{_batch}.samples.tsv"
-
-
-# *_list - list of files for compression in that order
-# *_hist - k-mer histogram
-# *_nscl - number of sequence and cumulative length
-# *_seq - files with sequences (fa / simpl
-# *_compr - compressed dataset
 
 
 def fn_tree_sorted(_batch):
@@ -119,7 +117,51 @@ def fn_nodes_sorted(_batch):
     return f"{dir_intermediate()}/tree/{_batch}.nodes"
 
 
-# Assemblies
+####################################################################
+# Files of the same type for individual protocols (asm / pre / post)
+####################################################################
+#
+# *_list - list of files for compression in that order
+# *_hist - k-mer histogram
+# *_nscl - number of sequence and cumulative length
+# *_seq - files with sequences (fa / simpl)
+# *_compr - compressed dataset
+#
+
+
+def fn_compr(_batch, protocol):
+    return f"{dir_output()}/{protocol}/{_batch}.{protocol}.tar.xz"
+
+
+def fn_compr_summary(_batch, protocol):
+    return f"{dir_intermediate()}/{protocol}/{_batch}.{protocol}.tar.xz.summary"
+
+
+def fn_nscl(_batch, protocol):
+    return f"{dir_intermediate()}/{protocol}/{_batch}.{protocol}.nscl"
+
+
+def fn_nscl_summary(_batch, protocol):
+    return f"{dir_intermediate()}/{protocol}/{_batch}.{protocol}.summary"
+
+
+def fn_hist(_batch, protocol):
+    return f"{dir_intermediate()}/{protocol}/{_batch}.{protocol}.hist"
+
+
+def fn_hist_summary(_batch, protocol):
+    return f"{dir_intermediate()}/{protocol}/{_batch}.{protocol}.hist.summary"
+
+
+def fn_list(_batch, protocol):
+    return f"{dir_intermediate()}/{protocol}/{_batch}.{protocol}.list"
+
+
+############################################
+# Specialized files for individual protocols
+############################################
+
+# ASM
 
 
 def fn_asm_seq_dir(_batch):
@@ -130,70 +172,14 @@ def fn_asm_seq(_batch, _sample):
     return f"{dir_intermediate()}/asm/{_batch}/{_sample}.fa"
 
 
-def fn_asm_list(_batch):
-    return f"{dir_intermediate()}/asm/{_batch}.asm.list"
-
-
-def fn_asm_hist(_batch):
-    return f"{dir_intermediate()}/asm/{_batch}.asm.hist"
-
-
-def fn_asm_hist_summary(_batch):
-    return fn_asm_hist(_batch) + ".summary"
-
-
-def fn_asm_nscl(_batch):
-    return f"{dir_intermediate()}/asm/{_batch}.asm.nscl"
-
-
-def fn_asm_nscl_summary(_batch):
-    return fn_asm_nscl(_batch) + ".summary"
-
-
-def fn_asm_compr(_batch):
-    return f"{dir_output()}/asm/{_batch}.asm.tar.xz"
-
-
-def fn_asm_compr_summary(_batch):
-    return fn_asm_compr(_batch) + ".summary"
-
-
-# Pre-propagation simplitigs
+# PRE
 
 
 def fn_pre_seq(_batch, _sample):
     return f"{dir_intermediate()}/pre/{_batch}/{_sample}.simpl"
 
 
-def fn_pre_list(_batch):
-    return f"{dir_intermediate()}/pre/{_batch}.pre.list"
-
-
-def fn_pre_hist(_batch):
-    return f"{dir_intermediate()}/pre/{_batch}.pre.hist"
-
-
-def fn_pre_hist_summary(_batch):
-    return fn_pre_hist(_batch) + ".summary"
-
-
-def fn_pre_nscl(_batch):
-    return f"{dir_intermediate()}/pre/{_batch}.pre.nscl"
-
-
-def fn_pre_nscl_summary(_batch):
-    return fn_pre_nscl(_batch) + ".summary"
-
-
-def fn_pre_compr(_batch):
-    return f"{dir_output()}/pre/{_batch}.pre.tar.xz"
-
-
-def fn_pre_compr_summary(_batch):
-    return fn_pre_compr(_batch) + ".summary"
-
-
-# Post-propagation simplitigs
+# POST
 
 
 def fn_post_seq0(_batch, _node):
@@ -202,34 +188,6 @@ def fn_post_seq0(_batch, _node):
 
 def fn_post_seq(_batch, _node):
     return f"{dir_intermediate()}/post/{_batch}/{_node}.simpl"
-
-
-def fn_post_list(_batch):
-    return f"{dir_intermediate()}/post/{_batch}.post.list"
-
-
-def fn_post_hist(_batch):
-    return f"{dir_intermediate()}/post/{_batch}.post.hist"
-
-
-def fn_post_hist_summary(_batch):
-    return fn_post_hist(_batch) + ".summary"
-
-
-def fn_post_nscl(_batch):
-    return f"{dir_intermediate()}/post/{_batch}.post.nscl"
-
-
-def fn_post_nscl_summary(_batch):
-    return fn_post_nscl(_batch) + ".summary"
-
-
-def fn_post_compr(_batch):
-    return f"{dir_output()}/post/{_batch}.post.tar.xz"
-
-
-def fn_post_compr_summary(_batch):
-    return fn_post_compr(_batch) + ".summary"
 
 
 ## WILDCARD FUNCTIONS

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -89,15 +89,15 @@ def dir_prophyle_propagation(_batch):
 #####################################
 
 
-def fn_stats_global():
+def fn_stats_batches():
     return f"{dir_output()}/global_stats.tsv"
 
 
-def fn_stats_batch_global(_batch):
+def fn_stats_batches_1batch(_batch):
     return f"{dir_intermediate()}/stats/{_batch}.global.tsv"
 
 
-def fn_stats_samples(_batch):
+def fn_stats_genomes(_batch):
     return f"{dir_intermediate()}/stats/{_batch}.samples.tsv"
 
 
@@ -155,8 +155,6 @@ def fn_hist(_batch, _protocol):
 
 def fn_hist_summary(_batch, _protocol):
     return f"{dir_intermediate()}/{_protocol}/{_batch}.{_protocol}.hist.summary"
-
-
 
 
 ############################################

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -129,32 +129,34 @@ def fn_nodes_sorted(_batch):
 #
 
 
-def fn_compr(_batch, protocol):
-    return f"{dir_output()}/{protocol}/{_batch}.{protocol}.tar.xz"
+def fn_list(_batch, _protocol):
+    return f"{dir_intermediate()}/{_protocol}/{_batch}.{_protocol}.list"
 
 
-def fn_compr_summary(_batch, protocol):
-    return f"{dir_intermediate()}/{protocol}/{_batch}.{protocol}.tar.xz.summary"
+def fn_compr(_batch, _protocol):
+    return f"{dir_output()}/{_protocol}/{_batch}.{_protocol}.tar.xz"
 
 
-def fn_nscl(_batch, protocol):
-    return f"{dir_intermediate()}/{protocol}/{_batch}.{protocol}.nscl"
+def fn_compr_summary(_batch, _protocol):
+    return f"{dir_intermediate()}/{_protocol}/{_batch}.{_protocol}.tar.xz.summary"
 
 
-def fn_nscl_summary(_batch, protocol):
-    return f"{dir_intermediate()}/{protocol}/{_batch}.{protocol}.summary"
+def fn_nscl(_batch, _protocol):
+    return f"{dir_intermediate()}/{_protocol}/{_batch}.{_protocol}.nscl"
 
 
-def fn_hist(_batch, protocol):
-    return f"{dir_intermediate()}/{protocol}/{_batch}.{protocol}.hist"
+def fn_nscl_summary(_batch, _protocol):
+    return f"{dir_intermediate()}/{_protocol}/{_batch}.{_protocol}.summary"
 
 
-def fn_hist_summary(_batch, protocol):
-    return f"{dir_intermediate()}/{protocol}/{_batch}.{protocol}.hist.summary"
+def fn_hist(_batch, _protocol):
+    return f"{dir_intermediate()}/{_protocol}/{_batch}.{_protocol}.hist"
 
 
-def fn_list(_batch, protocol):
-    return f"{dir_intermediate()}/{protocol}/{_batch}.{protocol}.list"
+def fn_hist_summary(_batch, _protocol):
+    return f"{dir_intermediate()}/{_protocol}/{_batch}.{_protocol}.hist.summary"
+
+
 
 
 ############################################

--- a/workflow/rules/other.smk
+++ b/workflow/rules/other.smk
@@ -8,9 +8,10 @@ rule tar_xz:
     Compress files using xz in a given order
     """
     input:
-        list="{pref}.{stage}.list",
+        #list=f"{dir_intermediate()}/{pre}/{_batch}.pre.list",
+        list=fn_list("{batch}", "{protocol}"),
     output:
-        xz="{pref}.{stage}.tar.xz",
+        xz=fn_compr("{batch}", "{protocol}"),
     shell:
         """
         tar cvf - -C $(dirname "{input.list}") -T "{input.list}" --dereference \\
@@ -24,13 +25,13 @@ rule tar_xz_summary:
     Compress files using xz in a given order
     """
     input:
-        xz="{pref}.{stage}.tar.xz",
+        xz=fn_compr("{batch}", "{protocol}"),
     output:
-        xz="{pref}.{stage}.tar.xz.summary",
+        xz_summary=fn_compr_summary("{batch}", "{protocol}"),
     shell:
         """
         printf '%s\\t%s\\n' \\
-            {wildcards.stage}_xz_size $(wc -c < "{input.xz}") \\
+            {wildcards.protocol}_xz_size $(wc -c < "{input.xz}") \\
             > {output}
         """
 
@@ -43,9 +44,9 @@ rule histogram:
 
     """
     input:
-        list="{pref}.{stage}.list",
+        list=fn_list("{batch}", "{protocol}"),
     output:
-        hist="{pref}.{stage}.hist",
+        hist=fn_hist("{batch}", "{protocol}"),
     params:
         hjf=snakemake.workflow.srcdir("../scripts/histogram_using_jf.sh"),
         lfa=snakemake.workflow.srcdir("../scripts/file_list_to_fa.py"),
@@ -61,9 +62,9 @@ rule histogram:
 
 rule histogram_summary:
     input:
-        hist="{pref}.{stage}.hist",
+        hist=fn_hist("{batch}", "{protocol}"),
     output:
-        summ="{pref}.{stage}.hist.summary",
+        hist_summary=fn_hist_summary("{batch}", "{protocol}"),
     params:
         s=snakemake.workflow.srcdir("../scripts/summarize_histogram.py"),
     conda:
@@ -71,16 +72,16 @@ rule histogram_summary:
     shell:
         """
         {params.s} {input.hist} \\
-            --add-prefix {wildcards.stage}_ \\
-            > {output.summ}
+            --add-prefix {wildcards.protocol}_ \\
+            > {output.hist_summary}
         """
 
 
 rule nscl:
     input:
-        list="{pref}.{stage}.list",
+        list=fn_list("{batch}", "{protocol}"),
     output:
-        nscl="{pref}.{stage}.nscl",
+        nscl=fn_nscl("{batch}", "{protocol}"),
     params:
         ss=snakemake.workflow.srcdir("../scripts/file_list_to_seq_summaries.py"),
     conda:
@@ -94,9 +95,9 @@ rule nscl:
 
 rule nscl_summary:
     input:
-        nscl="{pref}.{stage}.nscl",
+        nscl=fn_nscl("{batch}", "{protocol}"),
     output:
-        summ="{pref}.{stage}.nscl.summary",
+        nscl_summary=fn_nscl("{batch}", "{protocol}"),
     params:
         s=snakemake.workflow.srcdir("../scripts/summarize_nscl.py"),
     conda:
@@ -104,6 +105,6 @@ rule nscl_summary:
     shell:
         """
         {params.s} {input.nscl} \\
-            --add-prefix {wildcards.stage}_ \\
-            > {output.summ}
+            --add-prefix {wildcards.protocol}_ \\
+            > {output.nscl_summary}
         """

--- a/workflow/rules/other.smk
+++ b/workflow/rules/other.smk
@@ -7,11 +7,11 @@ rule tar_xz:
     """
     Compress files using xz in a given order
     """
+    output:
+        xz=fn_compr("{batch}", "{protocol}"),
     input:
         #list=f"{dir_intermediate()}/{pre}/{_batch}.pre.list",
         list=fn_list("{batch}", "{protocol}"),
-    output:
-        xz=fn_compr("{batch}", "{protocol}"),
     shell:
         """
         tar cvf - -C $(dirname "{input.list}") -T "{input.list}" --dereference \\
@@ -24,15 +24,15 @@ rule tar_xz_summary:
     """
     Compress files using xz in a given order
     """
+    output:
+        summary=fn_compr_summary("{batch}", "{protocol}"),
     input:
         xz=fn_compr("{batch}", "{protocol}"),
-    output:
-        xz_summary=fn_compr_summary("{batch}", "{protocol}"),
     shell:
         """
         printf '%s\\t%s\\n' \\
             {wildcards.protocol}_xz_size $(wc -c < "{input.xz}") \\
-            > {output}
+            > {output.summary}
         """
 
 
@@ -43,10 +43,10 @@ rule histogram:
        - todo: check tmp dir; might run out on the cluster
 
     """
-    input:
-        list=fn_list("{batch}", "{protocol}"),
     output:
         hist=fn_hist("{batch}", "{protocol}"),
+    input:
+        list=fn_list("{batch}", "{protocol}"),
     params:
         hjf=snakemake.workflow.srcdir("../scripts/histogram_using_jf.sh"),
         lfa=snakemake.workflow.srcdir("../scripts/file_list_to_fa.py"),
@@ -61,10 +61,10 @@ rule histogram:
 
 
 rule histogram_summary:
+    output:
+        summary=fn_hist_summary("{batch}", "{protocol}"),
     input:
         hist=fn_hist("{batch}", "{protocol}"),
-    output:
-        hist_summary=fn_hist_summary("{batch}", "{protocol}"),
     params:
         s=snakemake.workflow.srcdir("../scripts/summarize_histogram.py"),
     conda:
@@ -73,15 +73,15 @@ rule histogram_summary:
         """
         {params.s} {input.hist} \\
             --add-prefix {wildcards.protocol}_ \\
-            > {output.hist_summary}
+            > {output.summary}
         """
 
 
 rule nscl:
-    input:
-        list=fn_list("{batch}", "{protocol}"),
     output:
         nscl=fn_nscl("{batch}", "{protocol}"),
+    input:
+        list=fn_list("{batch}", "{protocol}"),
     params:
         ss=snakemake.workflow.srcdir("../scripts/file_list_to_seq_summaries.py"),
     conda:
@@ -94,10 +94,10 @@ rule nscl:
 
 
 rule nscl_summary:
+    output:
+        summary=fn_nscl_summary("{batch}", "{protocol}"),
     input:
         nscl=fn_nscl("{batch}", "{protocol}"),
-    output:
-        nscl_summary=fn_nscl("{batch}", "{protocol}"),
     params:
         s=snakemake.workflow.srcdir("../scripts/summarize_nscl.py"),
     conda:
@@ -106,5 +106,5 @@ rule nscl_summary:
         """
         {params.s} {input.nscl} \\
             --add-prefix {wildcards.protocol}_ \\
-            > {output.nscl_summary}
+            > {output.summary}
         """

--- a/workflow/rules/post.smk
+++ b/workflow/rules/post.smk
@@ -6,12 +6,12 @@
 # compute prophyle index
 # todo: output *
 checkpoint prophyle_index:
-    input:
-        w_batch_asms,
-        nw=fn_tree_sorted(_batch="{batch}"),
     output:
         d1=directory(dir_prophyle(_batch="{batch}")),
         d2=directory(dir_prophyle_propagation(_batch="{batch}")),
+    input:
+        w_batch_asms,
+        nw=fn_tree_sorted(_batch="{batch}"),
     params:
         k=31,
         asm_dir=fn_asm_seq_dir("{batch}"),
@@ -29,10 +29,10 @@ rule post_seq:
     """
     Compute simplitigs from an assembly and put them into a text file (1 simplitig per line)
     """
-    input:
-        fa=fn_post_seq0(_batch="{batch}", _node="{node}"),
     output:
         txt=fn_post_seq(_batch="{batch}", _node="{node}"),
+    input:
+        fa=fn_post_seq0(_batch="{batch}", _node="{node}"),
     conda:
         "../envs/env.yaml"
     shell:

--- a/workflow/rules/post.smk
+++ b/workflow/rules/post.smk
@@ -50,7 +50,7 @@ rule post_list:
         fa=w_batch_posts,
         dpp=dir_prophyle_propagation(_batch="{batch}"),
     output:
-        list=fn_post_list(_batch="{batch}"),
+        list=fn_list(_batch="{batch}", protocol="post"),
     run:
         generate_file_list(
             input.list,

--- a/workflow/rules/post.smk
+++ b/workflow/rules/post.smk
@@ -50,7 +50,7 @@ rule post_list:
         fa=w_batch_posts,
         dpp=dir_prophyle_propagation(_batch="{batch}"),
     output:
-        list=fn_list(_batch="{batch}", protocol="post"),
+        list=fn_list(_batch="{batch}", _protocol="post"),
     run:
         generate_file_list(
             input.list,

--- a/workflow/rules/pre.smk
+++ b/workflow/rules/pre.smk
@@ -32,7 +32,7 @@ rule pre_list:
         list=fn_leaves_sorted(_batch="{batch}"),
         fa=w_batch_pres,
     output:
-        list=fn_list(_batch="{batch}", protocol="pre"),
+        list=fn_list(_batch="{batch}", _protocol="pre"),
     run:
         generate_file_list(
             input.list,

--- a/workflow/rules/pre.smk
+++ b/workflow/rules/pre.smk
@@ -32,7 +32,7 @@ rule pre_list:
         list=fn_leaves_sorted(_batch="{batch}"),
         fa=w_batch_pres,
     output:
-        list=fn_pre_list(_batch="{batch}"),
+        list=fn_list(_batch="{batch}", protocol="pre"),
     run:
         generate_file_list(
             input.list,

--- a/workflow/rules/pre.smk
+++ b/workflow/rules/pre.smk
@@ -28,11 +28,11 @@ rule pre_list:
     """
     Make a list of pre-propagation simplitig files
     """
+    output:
+        list=fn_list(_batch="{batch}", _protocol="pre"),
     input:
         list=fn_leaves_sorted(_batch="{batch}"),
         fa=w_batch_pres,
-    output:
-        list=fn_list(_batch="{batch}", _protocol="pre"),
     run:
         generate_file_list(
             input.list,

--- a/workflow/rules/stats.smk
+++ b/workflow/rules/stats.smk
@@ -13,27 +13,26 @@ rule global_stats:
         """
 
 
-def get_stats_files():
+def get_stats_files(protocol):
     stats_files = []
 
-    for protocol in "asm", "pre", "post":
-        if config[f"compress_{protocol}"]:
-            if config["kmer_histograms"]:
-                stats_files.append(fn_hist_summary(_batch="{batch}", protocol=protocol))
+    if config[f"compress_{protocol}"]:
+        if config["kmer_histograms"]:
+            stats_files.append(fn_hist_summary(_batch="{batch}", _protocol=protocol))
 
-            stats_files.extend(
-                (
-                    fn_nscl_summary(_batch="{batch}", protocol=protocol),
-                    fn_compr_summary(_batch="{batch}", protocol=protocol),
-                )
+        stats_files.extend(
+            (
+                fn_nscl_summary(_batch="{batch}", _protocol=protocol),
+                fn_compr_summary(_batch="{batch}", _protocol=protocol),
             )
+        )
 
     return stats_files
 
 
 rule stats_global_sample:
     input:
-        get_stats_files(),
+        [get_stats_files(protocol=x) for x in ("asm", "pre", "post")],
     output:
         fn_stats_batch_global(_batch="{batch}"),
     shell:

--- a/workflow/rules/stats.smk
+++ b/workflow/rules/stats.smk
@@ -36,6 +36,7 @@ def get_stats_files(protocol):
                 fn_compr_summary(_batch="{batch}", _protocol=protocol),
             )
         )
+    print(stats_files)
 
     return stats_files
 

--- a/workflow/rules/stats.smk
+++ b/workflow/rules/stats.smk
@@ -36,7 +36,6 @@ def get_stats_files(protocol):
                 fn_compr_summary(_batch="{batch}", _protocol=protocol),
             )
         )
-    print(stats_files)
 
     return stats_files
 

--- a/workflow/rules/stats.smk
+++ b/workflow/rules/stats.smk
@@ -15,38 +15,19 @@ rule global_stats:
 
 def get_stats_files():
     stats_files = []
-    if config["generate_assembly_stats"]:
-        if config["kmer_histograms"]:
-            stats_files.append(fn_asm_hist_summary(_batch="{batch}"))
 
-        stats_files.extend(
-            (
-                fn_asm_nscl_summary(_batch="{batch}"),
-                fn_asm_compr_summary(_batch="{batch}"),
+    for protocol in "asm", "pre", "post":
+        if config[f"compress_{protocol}"]:
+            if config["kmer_histograms"]:
+                stats_files.append(fn_hist_summary(_batch="{batch}", protocol=protocol))
+
+            stats_files.extend(
+                (
+                    fn_nscl_summary(_batch="{batch}", protocol=protocol),
+                    fn_compr_summary(_batch="{batch}", protocol=protocol),
+                )
             )
-        )
-    if config["generate_prepropagation_stats"]:
-        if config["kmer_histograms"]:
-            stats_files.append(
-                fn_pre_hist_summary(_batch="{batch}"),
-            )
-        stats_files.extend(
-            (
-                fn_pre_nscl_summary(_batch="{batch}"),
-                fn_pre_compr_summary(_batch="{batch}"),
-            )
-        )
-    if config["generate_postpropagation_stats"]:
-        if config["kmer_histograms"]:
-            stats_files.append(
-                fn_post_hist_summary(_batch="{batch}"),
-            )
-        stats_files.extend(
-            (
-                fn_post_nscl_summary(_batch="{batch}"),
-                fn_post_compr_summary(_batch="{batch}"),
-            )
-        )
+
     return stats_files
 
 

--- a/workflow/rules/tree.smk
+++ b/workflow/rules/tree.smk
@@ -8,12 +8,12 @@ rule tree_postprocessing:
     """
     Get a cleaned tree and all auxiliary files
     """
-    input:
-        nw=fn_tree_dirty(_batch="{batch}"),
     output:
         nw=fn_tree_sorted(_batch="{batch}"),
         leaves=fn_leaves_sorted(_batch="{batch}"),
         nodes=fn_nodes_sorted(_batch="{batch}"),
+    input:
+        nw=fn_tree_dirty(_batch="{batch}"),
     params:
         script=snakemake.workflow.srcdir("../scripts/postprocess_tree.py"),
     conda:
@@ -38,10 +38,10 @@ rule symlink_nw_tree:
     """
     Symlink a phylogenetic tree if possible (nw)
     """
-    input:
-        nw=dir_input() / "{batch}.nw",
     output:
         nw=fn_tree_dirty(_batch="{batch}"),
+    input:
+        nw=dir_input() / "{batch}.nw",
     params:
         relative_path=lambda wildcards, input, output: os.path.relpath(
             input.nw, start=os.path.dirname(output.nw)
@@ -56,10 +56,10 @@ rule tree_newick_mashtree:
     """
     Infer a phylogenetic tree from the assemblies belonging to a given batch
     """
-    input:
-        w_batch_asms,
     output:
         nw=fn_tree_dirty(_batch="{batch}"),
+    input:
+        w_batch_asms,
     threads: 8
     conda:
         "../envs/mashtree.yaml"


### PR DESCRIPTION
Large refactoring to better systemize files generated along the pipeline and make them more understandable, and to simplify the code.

closes #7
