### PR TITLE
Tighten osx-arm64 dependencies

### DIFF
--- a/workflow/envs/basic_env.yaml
+++ b/workflow/envs/basic_env.yaml
@@ -1,10 +1,9 @@
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - ete3 ==3.1.3
   - seqtk ==1.4
-  - xopen >1.7.0
+  - xopen >=1.7,<2.1
   - pandas ==2.1.1
   - make ==4.3

--- a/workflow/envs/jellyfish.yaml
+++ b/workflow/envs/jellyfish.yaml
@@ -1,6 +1,6 @@
 channels:
+  - conda-forge
   - bioconda
-  - defaults
 dependencies:
-  - kmer-jellyfish >=2.2
-  - xopen >=0.7.3
+  - kmer-jellyfish >=2.3,<2.4
+  - xopen >=1.7,<2.1


### PR DESCRIPTION
Closes #108.
Closes #109.

This PR only fixes dependency availability on osx-arm64:
- relaxes the xopen pin while keeping an upper bound;
- replaces the old jellyfish package with kmer-jellyfish;
- normalizes Bioconda channel order.

The GitHub Actions conda/mamba frontend issue is handled separately in #116.